### PR TITLE
[FIX] fixed sign with wrong id format and other things

### DIFF
--- a/authentication/jwt.go
+++ b/authentication/jwt.go
@@ -23,7 +23,7 @@ var (
 func Sign(userId primitive.ObjectID) (*customTypes.Tokens, error) {
 
 	acClaim := &types.SignedDetails{
-		ID: userId.Hex(),
+		ID: ValidateUserID(userId.Hex()),
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(1 * time.Hour)),
 			Issuer:    "PlusOne",
@@ -31,7 +31,7 @@ func Sign(userId primitive.ObjectID) (*customTypes.Tokens, error) {
 	}
 
 	rfClaim := &types.SignedDetails{
-		ID: userId.Hex(),
+		ID: ValidateUserID(userId.Hex()),
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(1 * time.Hour)),
 			Issuer:    "PlusOne",

--- a/directives/isAuthenticated.go
+++ b/directives/isAuthenticated.go
@@ -2,7 +2,6 @@ package directives
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	auth "parties-app/backend/authentication"
 	"parties-app/backend/errorHandler"
@@ -29,13 +28,11 @@ func IsAuthenticated(ctx context.Context, obj interface{}, next graphql.Resolver
 
 	claims, valid, parseErr := auth.ParseAccessToken(*token)
 	if !valid && parseErr != nil {
-		if claims.ExpiresAt.Unix() > time.Now().Unix() {
+		if claims != nil && claims.ExpiresAt.Unix() > time.Now().Unix() {
 			errorHandler.HandleError(ctx, http.StatusRequestTimeout, errorHandler.RefreshToken)
 		}
 		return nil, errorHandler.ValidateErrorMessage(http.StatusUnauthorized, *parseErr)
 	}
-
-	fmt.Println(claims.ID)
 	newContext := context.WithValue(ctx, userCtxKey, claims.ID)
 
 	return next(newContext)

--- a/graph/resolvers/user.resolvers.go
+++ b/graph/resolvers/user.resolvers.go
@@ -73,13 +73,11 @@ func (r *queryResolver) Me(ctx context.Context) (*customTypes.User, error) {
 	userId := directives.ForContext(ctx)
 	if len(userId) < 5 {
 		errorHandler.HandleError(ctx, http.StatusNotAcceptable, "The authorization header is not found! (ForContext)")
-		fmt.Println(userId)
 		return nil, errors.New("the authorization header is not found (ForContext)")
 	}
 	id, err := authentication.ConvertUserIDStringToObjectID(userId)
 	if err != nil {
 		errorHandler.HandleError(ctx, http.StatusNotAcceptable, "The user id provided is invalid! (ConvertUserIDStringToObjectID)")
-		fmt.Println(id)
 		return nil, err
 	}
 	user, found, err := database.GetUserByID(*id)

--- a/server.go
+++ b/server.go
@@ -40,5 +40,5 @@ func main() {
 
 	r.Use(middleware.CorsMiddleware())
 
-	r.Run()
+	r.Run(":3000")
 }


### PR DESCRIPTION
# More details about the problem

Sign function sign a string with ID

## First problem

**Problem**

The sign id was just `ID.hex()` and it returns `ObjectID(ID)` which is wrong

**Solution**

By using function `ValidateUserID(ID.hex())`, it returns `ID` only instead `ObjectID(ID)`

## Second problem

The function that validate the access token is not correctly, because if the access token is not valid, then the `Claims` that it return is undefined, but the code still trying to access property of `Claims`, so I just have to add one more condition to the if statement

**Problem**

```go
if claims.ExpiresAt.Unix() > time.Now().Unix() {
```

**Solution**

```go
if claims != nil && claims.ExpiresAt.Unix() > time.Now().Unix() {
```